### PR TITLE
Fix `_gen_potcar_summary_stats` and tests

### DIFF
--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2388,7 +2388,8 @@ def _gen_potcar_summary_stats(
     func_dir_exist: dict[str, str] = {}
     vasp_psp_dir = vasp_psp_dir or SETTINGS.get("PMG_VASP_PSP_DIR")
     for func, func_dir in PotcarSingle.functional_dir.items():
-        if os.path.isdir(f"{vasp_psp_dir}/{func_dir}"):
+        func_dir = f"{vasp_psp_dir}/{func_dir}"
+        if os.path.isdir(func_dir):
             func_dir_exist[func] = func_dir
         else:
             warnings.warn(f"missing {func_dir} POTCAR directory.")
@@ -2402,8 +2403,8 @@ def _gen_potcar_summary_stats(
         new_summary_stats.setdefault(func, {})  # initialize dict if key missing
 
         potcar_list = [
-            *glob(f"{vasp_psp_dir}/{func_dir}/POTCAR*"),
-            *glob(f"{vasp_psp_dir}/{func_dir}/*/POTCAR*"),
+            *glob(f"{func_dir}/POTCAR*"),
+            *glob(f"{func_dir}/*/POTCAR*"),
         ]
         for potcar in potcar_list:
             psp = PotcarSingle.from_file(potcar)

--- a/pymatgen/io/vasp/inputs.py
+++ b/pymatgen/io/vasp/inputs.py
@@ -2387,12 +2387,11 @@ def _gen_potcar_summary_stats(
     """
     func_dir_exist: dict[str, str] = {}
     vasp_psp_dir = vasp_psp_dir or SETTINGS.get("PMG_VASP_PSP_DIR")
-    for func, cpsp_dir in PotcarSingle.functional_dir.items():
-        cpsp_dir = f"{vasp_psp_dir}/{cpsp_dir}"
-        if os.path.isdir(cpsp_dir):
-            func_dir_exist[func] = cpsp_dir
+    for func, func_dir in PotcarSingle.functional_dir.items():
+        if os.path.isdir(f"{vasp_psp_dir}/{func_dir}"):
+            func_dir_exist[func] = func_dir
         else:
-            warnings.warn(f"missing {cpsp_dir} POTCAR directory.")
+            warnings.warn(f"missing {func_dir} POTCAR directory.")
 
     # use append = True if a new POTCAR library is released to add new summary stats
     # without completely regenerating the dict of summary stats


### PR DESCRIPTION
Ensures that path specs are correct in the search for POTCARs to generate a library of summary stats with. Avoids duplicating path basenames.